### PR TITLE
Remove tests for non Financial-Times Githubs orgs.

### DIFF
--- a/lib/get-repo.js
+++ b/lib/get-repo.js
@@ -15,7 +15,6 @@ module.exports = async (repoId, versionId, language) => {
     let repo;
 
     try {
-        console.log({ repoId, versionId, language });
         repo = await repoData.getVersion(repoId, versionId);
     } catch (error) {
         throw new Error(`Could not find repository for Origami component "${repoId}@${versionId}". ${error.message}`);


### PR DESCRIPTION
Origami Codedocs supports components hosted by non Financial-Times
Github Organisations. This was added to support components hosted
on FT Labs, for example. Whilst this functionality should continue
to be supported until our component spec says otherwise,
there are no components in the registry outside the Financial Times 
organisation  now o-crossword has been moved from ftlabs.

Relates to: https://github.com/Financial-Times/origami-codedocs/pull/6