### PR TITLE
Support partial JSDoc results.

### DIFF
--- a/lib/jsdoc.js
+++ b/lib/jsdoc.js
@@ -42,8 +42,13 @@ class JsDoc extends Codedoc {
             const codeDirectoryRegex = new RegExp(codeDirectory, 'g');
             jsdocOutput = stdout.replace(codeDirectoryRegex, '');
         } catch (error) {
-            console.log('Jsdoc failed to generate doclets: ' + error.message);
-            throw new Error('Jsdoc failed to generate doclets');
+            if (error.killed) {
+                throw new Error('The jsdoc cli process was killed.');
+            } else {
+                // jsdoc returns a non-zero exit code when there is a parse error,
+                // even though jsdoc for other files has been returned successfully.
+                jsdocOutput = error.stdout;
+            }
         }
         // Validate jsdoc output can be parsed as json.
         try {

--- a/test/integration/get-repo.test.js
+++ b/test/integration/get-repo.test.js
@@ -36,6 +36,15 @@ describe('GET jsdoc/[componentId]', function () {
             .expect('Cache-Control', expectedDocletCacheControl);
     });
 
+    it('responds with some JSDoc doclets when JSDoc cannot be parsed in a portion of the codebase due to invalid syntax', () => {
+        return request(endpoint)
+            .get('/jsdoc/o-ads@14.1.0')
+            .set('x-api-key', codedocsApiKey)
+            .expect(200)
+            .expect('Content-Type', 'application/json;charset=utf-8')
+            .expect('Cache-Control', expectedDocletCacheControl);
+    });
+
     it('responds with 404 when component has no JS', () => {
         return request(endpoint)
             .get('/jsdoc/o-test-component@v1.0.33')


### PR DESCRIPTION
When a project contains invalid JSDoc an error is thrown. Instead
of returning nothing, return the valid JSDoc.