### PR TITLE
Start all the network requests at the same time so that it is less likely for api gateway to reach the 30 second timeout.

### DIFF
--- a/functions/health.js
+++ b/functions/health.js
@@ -82,7 +82,7 @@ exports.handler = RavenLambdaWrapper.handler(Raven, async (event) => {
     .promise();
 
     try {
-        await repoDataTest
+        await repoDataTest;
     } catch (error) {
         gtg = false;
         health.checks[2].ok = false;


### PR DESCRIPTION

before we were doing them sequentially and hitting the 30 second timeout limit of api gateway