### PR TITLE
make dependabot ignore snyk updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,12 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"
+    automerged_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "semver:minor"
+    ignored_updates:
+      - match:
+          dependency_name: "snyk"


### PR DESCRIPTION
snyk does too many updates and it makes for too many pull-requests for origami to review