### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,6 +1,14 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # Origami Codedocs
 
 Generates and stores codedocs (JsDoc and SassDoc) for Origami components.
+
+## Code
+
+origami-codedocs
 
 ## Service Tier
 
@@ -14,43 +22,31 @@ Production
 
 https://origami-codedocs.in.ft.com/prod/
 
-## Replaces
-
-* ft-sassdoc-service
-
 ## Host Platform
 
 AWS
 
 ## Contains Personal Data
 
-no
+No
 
 ## Contains Sensitive Data
 
-no
+No
 
-## Delivered By
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
 
-origami-team
+...or delete this placeholder if not applicable to this system
+-->
 
-## Supported By
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
 
-origami-team
-
-## Known About By
-
-* rowan.manning
-* jake.champion
-* lee.moody
-
-## Dependencies
-
-* github
-
-## Healthchecks
-
-* origami-codedocs.in.ft.com-https
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -86,7 +82,7 @@ An AWS Lambda checks the Origami Repo Data API that the request is for an Origam
 
 ## More Information
 
-This is the service which generates the code documentation on [https://registry.origami.ft.com](https://registry.origami.ft.com)
+This is the service which generates the code documentation on <https://registry.origami.ft.com>
 
 ## First Line Troubleshooting
 
@@ -116,3 +112,10 @@ To release merge to the master branch. CI will run tests and deploy changes to A
 
 Create deploy keys for the "DeployUserFor_Serverless_origami-codedocs" user under the "ft-tech-origami-prod" AWS account.
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/origami-codedocs/blob/runbook-no-relationships-2021-03-19/RUNBOOK.md) file has been automatically regenerated from the Biz Ops data for the **origami-codedocs** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **origami-codedocs** system in [Biz Ops](https://biz-ops.in.ft.com/System/origami-codedocs).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
