### PR TITLE
Upgrade node version

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -31,10 +31,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v2
-      - name: Use Node.js 10.x
+      - name: Use Node.js
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: 10.x
+          node-version: 14.x
       - uses: actions/cache@v2.1.5
         with:
           path: ~/.npm

--- a/.github/workflows/deploy-to-staging-and-test.yml
+++ b/.github/workflows/deploy-to-staging-and-test.yml
@@ -31,10 +31,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v2
-      - name: Use Node.js 10.x
+      - name: Use Node.js
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: 10.x
+          node-version: 14.x
       - uses: actions/cache@v2.1.5
         with:
           path: ~/.npm

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Generates JSDoc and SassDoc json for Origami components.
 
 ## Requirements
 
-Running Origami Codedocs requires [Node.js] 10.x and [npm].
+Running Origami Codedocs requires [Node.js] 14.x and [npm].
 
 ## Running Locally
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=10.16.0"
+    "node": ">=14.0.0"
   },
   "dependencies": {
     "@financial-times/origami-repo-data-client": "1.6.3",

--- a/serverless.yml
+++ b/serverless.yml
@@ -7,7 +7,7 @@ provider:
   memorySize: 256
   timeout: 30
   stage: ${opt:stage, self:custom.defaultStage}
-  runtime: nodejs10.x
+  runtime: nodejs14.x
   apiKeys:
     - ${self:custom.secret.CODEDOCS_API_KEY_NAME}
   deploymentBucket: ${self:service}-artefacts-${self:provider.stage}


### PR DESCRIPTION
AWS Lambda ending support for Node.js 10.x. Node 10.x end of life as of April 30, 2021.