### PR TITLE
Do not generate codedocs for unsupported Origami Versions [OR-303]

### DIFF
--- a/lib/get-repo.js
+++ b/lib/get-repo.js
@@ -20,6 +20,11 @@ module.exports = async (repoId, versionId, language) => {
         throw new Error(`"${repoId}@${versionId}" is of type "${repo.type}", only "module" or "null" types are supported.`);
     }
 
+    const supportedOrigamiVersions = ['1', '2.0', '2.1']; // 2.1 is a mistake in an existing component, n-notification
+    if (!supportedOrigamiVersions.includes(repo.origamiVersion)) {
+        throw new Error(`"${repoId}@${versionId}" has an "origamiVersion" of "${repo.origamiVersion}". Only "${supportedOrigamiVersions.join('", "')}" Origami Versions are supported.`);
+    }
+
     if (!Array.isArray(repo.languages) || !repo.languages.includes(language)) {
         throw new Error(`"${repoId}@${versionId}" does not have "${language}" to generate codedocs for.`);
     }


### PR DESCRIPTION
We plan to decommission origami-codedocs, and do not want it to attempt to generate codedocs for any future Origami Version.

I opted not to add tests here as:
- We do not have a "3.0" component released for an integration test.
- A unit test would require mocking out repo-data, which is of limited value (we would mostly be testing this mock) and doesn't seem worth it under the circumstances outlined above.